### PR TITLE
fix udp client

### DIFF
--- a/src/riemann/client.clj
+++ b/src/riemann/client.clj
@@ -106,7 +106,7 @@
            max-size 16384}
       :as opts}]
   (let [c (RiemannClient/udp host port)]
-    (-> c .transport .sendBufferSize (.set max-size))
+    (-> c .transport .transport .sendBufferSize (.set max-size))
     (try (connect-client c) (catch IOException e nil))
     c))
 


### PR DESCRIPTION
resolves the error when instantiating a udp client:

IllegalArgumentException No matching field found: sendBufferSize for class com.aphyr.riemann.client.AsynchronizeTransport
