### PR TITLE
Get tests passing

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,5 +8,6 @@ pom.xml
 .lein-deps-sum
 .lein-failures
 .lein-plugins
+.lein-repl-history
 .*.swp
 ~*

--- a/test/riemann/client_test.clj
+++ b/test/riemann/client_test.clj
@@ -34,9 +34,9 @@
 (deftest default-time
          (let [c (tcp-client)]
            (testing "undefined time"
-                    (let [t1 (* 1000 (System/currentTimeMillis))
+                    (let [t1 (quot (System/currentTimeMillis) 1000)
                           _ (send-event c {:service "test-no-time"})
-                          t2 (* 1000 (System/currentTimeMillis))
+                          t2 (quot (System/currentTimeMillis) 1000)
                           t  (-> c
                                  (query "service = \"test-no-time\"")
                                  first

--- a/test/riemann/codec_test.clj
+++ b/test/riemann/codec_test.clj
@@ -27,7 +27,10 @@
     (map->Msg)))
 
 (deftest protobufs
-         (let [roundtrip (comp decode-pb-msg encode-pb-msg)]
+         (let [roundtrip (fn [m] (-> m
+                                     encode-pb-msg
+                                     decode-pb-msg
+                                     (assoc :decode-time nil)))]
            (are [m] (= (msg m) (roundtrip m))
                 {}
                 {:ok true}


### PR DESCRIPTION
I was going to add an ExceptionReporter (https://github.com/aphyr/riemann-java-client/blob/master/src/main/java/com/aphyr/riemann/client/ExceptionReporter.java) option to the udp-client fn, but the tests were broken, so I fixed (?) those first. Then I realized ExceptionReporter isn't in the released java client, so I aborted for now.

Test fixes might still be useful though.  Commit comment has more info.
