### PR TITLE
Provide context when serialization fails

### DIFF
--- a/src/riemann/codec.clj
+++ b/src/riemann/codec.clj
@@ -83,7 +83,11 @@
       (when-let [v (get e k)]
         (let [a (Proto$Attribute/newBuilder)]
           (.setKey a (name k))
-          (.setValue a v)
+          (try (.setValue a v)
+               (catch java.lang.ClassCastException cce
+                 (throw (ex-info "Couldn't serialize event"
+                                 {:event e
+                                  :key k}))))
           (.addAttributes event a))))
     (.build event)))
 

--- a/test/riemann/codec_test.clj
+++ b/test/riemann/codec_test.clj
@@ -101,3 +101,24 @@
         expected (dissoc original :empty-attr)]
     (is (= (msg {:events [expected]})
            (roundtrip {:events [original]})))))
+
+(defn not-serializable-event
+  [not-serializable-value]
+  {:host "somehost"
+   :service "someservice"
+   :not-serializable not-serializable-value})
+
+(defn attempt-serialization
+  [value]
+  (try (roundtrip {:events [(not-serializable-event value)]})
+       (catch Throwable t
+         t)))
+
+(deftest attributes-with-non-serializable-values-should-result-in-exception-with-context
+  (are [value]
+    (let [ex (attempt-serialization value)]
+      (and (= (not-serializable-event value) (:event (ex-data ex)))
+           (= :not-serializable (:key (ex-data ex)))))
+    \c
+    {:some :stuff}
+    ["other" :things]))


### PR DESCRIPTION
Somewhat related to [my previous
PR](https://github.com/aphyr/riemann-clojure-client/pull/16): I noticed that
that I'd occasionally index an event that was impossible to serialize
(that is, with non-String custom attribute values) due to an error in my
Riemann config. The symptoms: inability to remotely query the index, and
a cryptic ClassCastException in the Riemann log.

This made the problem more difficult to diagnose than it ought to have
been. This PR aims to fix that by providing more context when event
serialization fails so that users can more quickly diagnose errors in
their Riemann configurations.