### PR TITLE
cleanup dependencies

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -1,11 +1,10 @@
-(defproject riemann-clojure-client "0.4.1"
+(defproject riemann-clojure-client "0.4.2"
   :description "Clojure client for the Riemann monitoring system"
   :url "https://github.com/aphyr/riemann-clojure-client"
   :license {:name "Eclipse Public License"
             :url "http://www.eclipse.org/legal/epl-v10.html"}
-  :dependencies [[org.clojure/tools.logging "0.2.3"]
-                 [less-awful-ssl "1.0.0"]
-                 [com.aphyr/riemann-java-client "0.4.0"]]
+  :dependencies [[less-awful-ssl "1.0.0"]
+                 [com.aphyr/riemann-java-client "0.4.1"]]
   :profiles {:dev {:dependencies [[org.clojure/clojure "1.6.0"]]}
              :bench {:dependencies [[org.clojure/clojure "1.6.0"]
                                     [criterium "0.4.1"]]

--- a/src/riemann/client.clj
+++ b/src/riemann/client.clj
@@ -33,8 +33,7 @@
            (java.net InetSocketAddress)
            (java.io IOException))
   (:require [less.awful.ssl :as ssl])
-  (:use riemann.codec)
-  (:use clojure.tools.logging))
+  (:use riemann.codec))
 
 (defn map-promise
   "Maps a riemann client promise by applying a function."


### PR DESCRIPTION
`clojure.tools.logging` isn't used in the client, I also bumped to the latest riemann-java-client dependency.