### PR TITLE
Use macro for assoc-default

### DIFF
--- a/src/riemann/codec.clj
+++ b/src/riemann/codec.clj
@@ -12,16 +12,16 @@
 
 (def event-keys (set (map keyword (Event/getBasis))))
 
-(defn assoc-default
+(defmacro assoc-default
   "Like assoc, but only alters the map if it does not already contain the given
   key.
 
   (assoc-default {} :foo 2)         ; {:foo 2}
   (assoc-default {:foo nil} :foo 2) ; {:foo nil}"
   [m k v]
-  (if (contains? m k)
-    m
-    (assoc m k v)))
+  `(if (contains? ~m ~k)
+    ~m
+    (assoc ~m ~k ~v)))
 
 (defn decode-pb-query
   "Transforms a java protobuf Query to a Query."


### PR DESCRIPTION
Hi,
I had the same issue as https://github.com/riemann/riemann-clojure-client/issues/15 

I have made assoc default a macro so that the second form is only
evaluated if necessary, which means that if we pass a :host key it will not evaluate
`(.. InetAddress getLocalHost getHostName)`, preventing the exception.

Feel free to merge if useful, thanks for the library!
