### PR TITLE
Receive microseconds in time_micro field

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -4,9 +4,9 @@
   :license {:name "Eclipse Public License"
             :url "http://www.eclipse.org/legal/epl-v10.html"}
   :dependencies [[less-awful-ssl "1.0.0"]
-                 [com.aphyr/riemann-java-client "0.4.1"]]
-  :profiles {:dev {:dependencies [[org.clojure/clojure "1.6.0"]]}
-             :bench {:dependencies [[org.clojure/clojure "1.6.0"]
+                 [io.riemann/riemann-java-client "0.4.2"]]
+  :profiles {:dev {:dependencies [[org.clojure/clojure "1.8.0"]]}
+             :bench {:dependencies [[org.clojure/clojure "1.8.0"]
                                     [criterium "0.4.1"]]
                      :jvm-opts ["-server" "-Xms1024m" "-Xmx1024m"
                                 "-XX:+UseParNewGC" "-XX:+UseConcMarkSweepGC"

--- a/src/riemann/client.clj
+++ b/src/riemann/client.clj
@@ -17,17 +17,17 @@
   Clients are resistant to failure; they will attempt to reconnect a dropped
   connection periodically. Note that clients will not automatically queue or
   retry failed sends."
-  (:import (com.aphyr.riemann.client RiemannBatchClient
-                                     RiemannClient
-                                     MapPromise
-                                     IPromise
-                                     Fn2
-                                     Transport
-                                     AsynchronousTransport
-                                     IRiemannClient
-                                     TcpTransport
-                                     UdpTransport
-                                     SSL)
+  (:import (io.riemann.riemann.client RiemannBatchClient
+                                      RiemannClient
+                                      MapPromise
+                                      IPromise
+                                      Fn2
+                                      Transport
+                                      AsynchronousTransport
+                                      IRiemannClient
+                                      TcpTransport
+                                      UdpTransport
+                                      SSL)
            (java.util List)
            (clojure.lang IDeref)
            (java.net InetSocketAddress)

--- a/test/riemann/client_test.clj
+++ b/test/riemann/client_test.clj
@@ -1,6 +1,6 @@
 (ns riemann.client-test
   (:import java.net.InetAddress
-           com.aphyr.riemann.client.OverloadedException)
+           io.riemann.riemann.client.OverloadedException)
   (:use riemann.client
         clojure.test))
 

--- a/test/riemann/codec_test.clj
+++ b/test/riemann/codec_test.clj
@@ -69,7 +69,7 @@
                            :description "yo"
                            :metric (float 1.8)
                            :tags ["a" "b" "c"]
-                           :time 12345
+                           :time 12345.0
                            :ttl (float 10)}]}
                 ; Custom attributes
                 {:events [{:host "a"
@@ -79,18 +79,34 @@
                            :metric (float 1.8)
                            :key1 "value1"
                            :key2 "value2"
-                           :time 12345
+                           :time 12345.0
                            :ttl (float 10)
                            :my-ns/key3 "value3"}]})
 
-           (let [m (msg {:events [{:host "a"
-                                   :service "b"
-                                   :state "c"
-                                   :description "yo"
-                                   :metric (float 1.8)
-                                   :tags ["a" "b" "c"]
-                                   :time 12345
-                                   :ttl (float 10)}]})]
+  ; Test time
+  (are [map event] (= (decode-pb-event-record (encode-pb-event map)) event)
+    {:host "sup" :time 1} (map->Event {:host "sup" :time 1.0})
+    {:host "sup" :time 100.500} (map->Event {:host "sup" :time 100.500}))
+
+  ; Test encoding
+  (testing "Protobuf encoding"
+    (let [proto-event (encode-pb-event {:host "sup" :time 1})]
+      (is (= (.getHost proto-event) "sup"))
+      (is (= (.getTime proto-event) 1))
+      (is (= (.getTimeMicros proto-event) 1000000)))
+    (let [proto-event (encode-pb-event {:host "sup" :time 100.500})]
+      (is (= (.getHost proto-event) "sup"))
+      (is (= (.getTime proto-event) 100))
+      (is (= (.getTimeMicros proto-event) 100500000))))
+
+  (let [m (msg {:events [{:host "a"
+                          :service "b"
+                          :state "c"
+                          :description "yo"
+                          :metric (float 1.8)
+                          :tags ["a" "b" "c"]
+                          :time 12345
+                          :ttl (float 10)}]})]
              ;(time (dotimes [n 10000000]
                      ;(roundtrip m))))))
              ))


### PR DESCRIPTION
[java client](https://github.com/riemann/riemann-java-client/pull/76)
Allows clients to send time in microseconds using the time_micros field in the protobuf definition.
Microsecond time is converted in seconds when decoding the message.

Also, com.aphyr => io.riemann package migration

I also upgraded the clojure version to 1.8, i think it is safe.
