### PR TITLE
Fix for microseconds support

### DIFF
--- a/src/riemann/codec.clj
+++ b/src/riemann/codec.clj
@@ -87,7 +87,7 @@
     (encode-pb-event
      (cond-> e
        (absent? :host) (assoc :host (.. InetAddress getLocalHost getHostName))
-       (absent? :time) (assoc :time (/ (System/currentTimeMillis) 1000))))))
+       (absent? :time) (assoc :time (/ (double (System/currentTimeMillis)) 1000))))))
 
 (defn decode-pb-msg
   "Transforms a java protobuf Msg to a defrecord Msg."

--- a/test/riemann/client_test.clj
+++ b/test/riemann/client_test.clj
@@ -19,13 +19,13 @@
 
 (deftest send-query
   (with-open [c (tcp-client :host "localhost")]
-    (let [e {:service "test" :state "ok"}]
+    (let [e {:service "test" :state "ok" :ttl 10}]
       (send-event c e)
       (let [e1 (first @(query c "service = \"test\" and state = \"ok\""))]
         (is (= (:service e) (:service e1)))
         (is (= (:state e) (:state e1)))
         (is (float? (:ttl e1)))
-        (is (integer? (:time e1)))))))
+        (is (float? (:time e1)))))))
 
 (deftest load-shedding-test
   (with-open [c (tcp-client)]
@@ -52,9 +52,9 @@
 (deftest default-time
   (with-open [c (tcp-client :host "localhost")]
     (testing "undefined time"
-      (let [t1 (quot (System/currentTimeMillis) 1000)
+      (let [t1 (/ (System/currentTimeMillis) 1000)
             _ @(send-event c {:service "test-no-time"})
-            t2 (quot (System/currentTimeMillis) 1000)
+            t2 (/ (System/currentTimeMillis) 1000)
             t  (-> c
                    (query "service = \"test-no-time\"")
                    deref
@@ -72,7 +72,7 @@
 
     (testing "with a given time"
       @(send-event c {:service "test-given-time" :time 1234})
-      (is (= 1234
+      (is (= 1234.0
              (-> c (query "service = \"test-given-time\"")
                  deref
                  first


### PR DESCRIPTION
Several fix for handling microseconds in the client.

- In codec.clj :
The default time when encoding an event with no :time is now a double. It is coherent with the default value when decoding [here](https://github.com/riemann/riemann-clojure-client/blob/master/src/riemann/codec.clj#L43). :

- `send-query` test : 
I added the :ttl key on the event; because if no :ttl is specified, the :ttl of the event returned by the query is nil (or the Riemann server used for the test needs to set a :ttl by defaut). 
I also modified `integer?` to `float?` because :time is not a int anymore (cf [here](https://github.com/riemann/riemann-clojure-client/blob/master/src/riemann/codec.clj#L41)).

- `default-time` test : 
`quot` is replaced by `/`, because the default event :time is now a double (in codec.clj). Before that, the test was in success because expressions like  `(<= (/ (System/currentTimeMillis) 1000) 1485296490619)`  was `true`.
`1234` is now `1234.0` because the time is a double now.

All tests are passing on my machine, using a Riemann server built with this PR in dependency ([riemann-clojure-client "0.4.4-SNAPSHOT"] in project.clj). 

What do you think about it ? 


