### PR TITLE
Version to 0.5.0-SNAPSHOT

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -1,10 +1,10 @@
-(defproject riemann-clojure-client "0.4.6-SNAPSHOT"
+(defproject riemann-clojure-client "0.5.0-SNAPSHOT"
   :description "Clojure client for the Riemann monitoring system"
   :url "https://github.com/aphyr/riemann-clojure-client"
   :license {:name "Eclipse Public License"
             :url "http://www.eclipse.org/legal/epl-v10.html"}
   :dependencies [[less-awful-ssl "1.0.0"]
-                 [io.riemann/riemann-java-client "0.4.5"]]
+                 [io.riemann/riemann-java-client "0.5.0-SNAPSHOT"]]
   :profiles {:dev {:dependencies [[org.clojure/clojure "1.8.0"]]}
              :bench {:dependencies [[org.clojure/clojure "1.8.0"]
                                     [criterium "0.4.1"]]

--- a/src/riemann/client.clj
+++ b/src/riemann/client.clj
@@ -167,14 +167,13 @@
                               (TcpTransport. (or remote-host host) remote-port local-host local-port))
                        (-> .sslContext
                            ;; (.set (SSL/sslContext key cert ca-cert))
-                           (.set (ssl/ssl-context key cert ca-cert)))
-                       (-> .cacheDns (.set cache-dns?))))
+                           (.set (ssl/ssl-context key cert ca-cert)))))
 
                    ; Standard client
-                   (doto (if-not local-host
-                            (RiemannClient/tcp (or remote-host host) remote-port)
-                            (RiemannClient/tcp (or remote-host host) remote-port local-host local-port))
-                     (-> .transport .cacheDns (.set cache-dns?))))]
+                   (if-not local-host
+                      (RiemannClient/tcp (or remote-host host) remote-port)
+                      (RiemannClient/tcp (or remote-host host) remote-port local-host local-port)))]
+
 
       ; Attempt to connect lazily.
       (try (connect! client)
@@ -208,8 +207,7 @@
             (doto (if-not local-host
                       (UdpTransport. (or remote-host host) (or remote-port port))
                       (UdpTransport. (or remote-host host) (or remote-port port) local-host local-port))
-              (-> .sendBufferSize (.set max-size))
-              (-> .cacheDns (.set cache-dns?))))]
+              (-> .sendBufferSize (.set max-size))))]
     (try (connect! c)
          (catch IOException e nil))
     c))


### PR DESCRIPTION
- reference riemann-java-client 0.5.0-SNAPSHOT for Netty 4.X 

(see https://github.com/riemann/riemann-java-client/pull/91)