### PR TITLE
Add auto-connect param to allow changing the WriteBufferLimit prior t…

### DIFF
--- a/test/riemann/client_test.clj
+++ b/test/riemann/client_test.clj
@@ -28,8 +28,7 @@
         (is (float? (:time e1)))))))
 
 (deftest load-shedding-test
-  (with-open [c (tcp-client)]
-    (close! c)
+  (with-open [c (tcp-client :auto-connect false)]
     (.. c transport (setWriteBufferLimit 2))
     (connect! c)
 


### PR DESCRIPTION
…o client connection.

- 0.5.0 riemann-java-client no longer supports reopening a closed client,
  this parameter can be used to make further configuration changes prior to opening
- Default value of auto-connect is true, which matches the current behaviour.