### PR TITLE
Type-hint port in client construction

### DIFF
--- a/src/riemann/client.clj
+++ b/src/riemann/client.clj
@@ -158,7 +158,7 @@
       (assert ca-cert))
 
     ; Create client
-    (let [remote-port   (or remote-port port (if tls? 5554 5555))
+    (let [remote-port (int (or remote-port port (if tls? 5554 5555)))
           client (if tls?
                    ; TLS client
                    (RiemannClient.


### PR DESCRIPTION
This fixes two reflection warnings in the `riemann.client` namespace:
```
% lein check
Compiling namespace riemann.client
Reflection warning, riemann/client.clj:166:31 - call to io.riemann.riemann.client.TcpTransport ctor can't be resolved.
Reflection warning, riemann/client.clj:174:22 - call to static method tcp on io.riemann.riemann.client.RiemannClient can't be resolved (argument types: java.lang.String, unknown).
Compiling namespace riemann.codec
```
Due to the usage of Riemann across our codebase, these warnings show up in basically every project in our builds. This also causes issues with using Graal to compile native images, which I ran into while writing the [solanum](https://github.com/greglook/solanum) monitoring daemon. I was able to mitigate this by falling back to direct Java interop to build the client, but it'd be nice to stick to the Clojure wrapper.