### PR TITLE
`falsy` valued attributes should not be dropped

### DIFF
--- a/src/riemann/codec.clj
+++ b/src/riemann/codec.clj
@@ -72,7 +72,7 @@
                         (.setTime       event (long (:time e)))))
     (when (:ttl e)          (.setTtl          event (:ttl e)))
     (doseq [k (clojure.set/difference (set (keys e)) event-keys)]
-      (when-let [v (get e k)]
+      (when-some [v (get e k)]
         (let [a (Proto$Attribute/newBuilder)]
           (.setKey a (str (when (namespace k) (str (namespace k) \/)) (name k)))
           (.setValue a (str v))

--- a/test/riemann/codec_test.clj
+++ b/test/riemann/codec_test.clj
@@ -118,3 +118,15 @@
         expected (dissoc original :empty-attr)]
     (is (= (msg {:events [expected]})
            (roundtrip {:events [original]})))))
+
+(deftest false-custom-attributes
+  (let [original {:host "host.1"
+                  :service "service.1"
+                  :nil-attr nil
+                  :false-attr false}
+        expected (-> original
+                     (dissoc :nil-attr)
+                     (assoc :false-attr "false"))]
+    (is (= (msg {:events [expected]})
+           (roundtrip {:events [original]}))
+        "false values should be converted to string and not be removed")))


### PR DESCRIPTION
Fixes: https://github.com/riemann/riemann-clojure-client/issues/45